### PR TITLE
Update pumsu

### DIFF
--- a/pumsu
+++ b/pumsu
@@ -177,7 +177,7 @@ def main():
   print("[*] uploading modules")
   if debug:
     print("[d] executing: hammer respository upload-content --id %s --product puppet --path %s" % (repo, out_dir))
-  upload_modules = subprocess.Popen("hammer repository upload-content --id %s --product puppet --path %s" % (repo, out_dir) , shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  upload_modules = subprocess.Popen("hammer repository upload-content --id %s --path %s" % (repo, out_dir) , shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (upload_output, upload_errors) = upload_modules.communicate()
   upload_modules.wait()
   print(upload_output)


### PR DESCRIPTION
removed "--product puppet" from upload modules, as of Satellite 6.3.3, this is no longer needed when specifying the repoid